### PR TITLE
Pin python docker version to workaround psycopg2 import error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 MS_DOCKER_UNITTEST:=FALSE
 
+# Import of psycopg2, which is used in aiopg and aiocypher unit tests, failed on Python 3.13.
+# psycopg2 reports support up to 3.12. See also https://github.com/psycopg/psycopg2/issues/1692
+CLOUDFIT_BASE_LABEL:=3.12
+
 include ./static-commontooling/make/lib_static_commontooling.mk
 include ./static-commontooling/make/standalone.mk
 include ./static-commontooling/make/pythonic.mk


### PR DESCRIPTION
# Details
The unit test reported this error: `ImportError: /root/.local/lib/python3.13/site-packages/psycopg2/_psycopg.cpython-313-x86_64-linux-gnu.so: undefined symbol: _PyInterpreterState_Get`

psycopg2 doesn't yet support Python 3.13 - see https://github.com/psycopg/psycopg2/issues/1692. The Python package reports that up to Python 3.12 is supported.

# Pivotal Story
Story URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
